### PR TITLE
Add proper namespaces support

### DIFF
--- a/XML/DragonML.cs
+++ b/XML/DragonML.cs
@@ -14,10 +14,13 @@ namespace DragonLib.XML
     {
         private static readonly Dictionary<Type, MemberInfo[]> TypeCache = new Dictionary<Type, MemberInfo[]>();
         private static readonly Dictionary<Type, DragonMLType> TargetCache = new Dictionary<Type, DragonMLType>();
-
+        private static HashSet<string> UsedNameSpaces = new HashSet<string>();
         public static string CreateNamespacedTag(string? tag, string? ns)
         {
             if (tag == null) return "";
+
+            UsedNameSpaces.Add(ns);
+
             return ns == null ? tag : $"{ns}:{tag}";
         }
 
@@ -85,7 +88,15 @@ namespace DragonLib.XML
                             else
                                 tag += $" {member.Name}=\"{(targetCustomSerializer != null ? targetCustomSerializer.Print(value, visited, indents, member.Name, settings) : FormatValueType(value))}\"";
                         }
-
+                        if (visited.Count == 1)
+                        {
+                            UsedNameSpaces.Add(settings.Namespace);
+                            foreach (var ns in UsedNameSpaces)
+                            {
+                                tag += $" xmlns:{ns}=\"{settings.NamespaceUri}\"";
+                            }
+                            UsedNameSpaces.Clear();
+                        }
                         if (complexMembers.Count == 0)
                         {
                             tag += " />\n";
@@ -97,7 +108,6 @@ namespace DragonLib.XML
 
                             tag += $"{indents}</{FormatName(type.Name)}>\n";
                         }
-
                         return tag;
                     }
                     else

--- a/XML/DragonMLSettings.cs
+++ b/XML/DragonMLSettings.cs
@@ -20,7 +20,7 @@ namespace DragonLib.XML
         /// Prefix namespace for system tags
         /// </summary>
         public string Namespace { get; set; } = "dragon";
-
+        public string NamespaceUri { get; set; } = "d.ml";
         public static DragonMLSettings Default => new DragonMLSettings();
 
         public static DragonMLSettings Slim => new DragonMLSettings


### PR DESCRIPTION
Generated XML was invalid because namespaces were not defined. Fixed that by accumulating all used NS's and printing them in root object.